### PR TITLE
定数定義を構文解析できるようにする

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1,0 +1,53 @@
+package ast
+
+import "github.com/sam8helloworld/uwscgo/token"
+
+type Node interface {
+	// デバッグ or テスト用
+	TokenLiteral() string
+}
+
+type Statement interface {
+	Node
+	statementNode()
+}
+
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+type Program struct {
+	Statements []Statement
+}
+
+func (p *Program) TokenLiteral() string {
+	if len(p.Statements) > 0 {
+		return p.Statements[0].TokenLiteral()
+	} else {
+		return ""
+	}
+}
+
+type DimStatement struct {
+	Token token.Token
+	Name  *Identifier
+	Value Expression
+}
+
+func (ds *DimStatement) statementNode() {}
+
+func (ds *DimStatement) TokenLiteral() string {
+	return ds.Token.Literal
+}
+
+type Identifier struct {
+	Token token.Token // token.IDENT
+	Value string
+}
+
+func (i *Identifier) expressionNode() {}
+
+func (i *Identifier) TokenLiteral() string {
+	return i.Token.Literal
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,0 +1,89 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/sam8helloworld/uwscgo/ast"
+	"github.com/sam8helloworld/uwscgo/lexer"
+	"github.com/sam8helloworld/uwscgo/token"
+)
+
+type Parser struct {
+	lexer     *lexer.Lexer
+	curToken  token.Token
+	peekToken token.Token
+}
+
+func NewParser(l *lexer.Lexer) *Parser {
+	p := &Parser{lexer: l}
+
+	// 2つのトークンを読み込むことでcurTokenとpeekTokenがセットされる
+	p.nextToken()
+	p.nextToken()
+	return p
+}
+
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	p.peekToken = p.lexer.NextToken()
+}
+
+func (p *Parser) ParseProgram() *ast.Program {
+	program := &ast.Program{}
+	program.Statements = []ast.Statement{}
+
+	for p.curToken.Type != token.EOF {
+		stmt := p.parseStatement()
+		if stmt != nil {
+			program.Statements = append(program.Statements, stmt)
+		}
+		p.nextToken()
+	}
+	fmt.Printf("%#v\n", program.Statements[0])
+	return program
+}
+
+func (p *Parser) parseStatement() ast.Statement {
+	switch p.curToken.Type {
+	case token.DIM:
+		return p.parseDimStatement()
+	default:
+		return nil
+	}
+}
+
+func (p *Parser) parseDimStatement() *ast.DimStatement {
+	stmt := &ast.DimStatement{Token: p.curToken}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+
+	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	// TODO: 文の右辺を構文解析していない1
+	for p.curTokenIs(token.DIM) {
+		p.nextToken()
+	}
+	return stmt
+}
+
+func (p *Parser) curTokenIs(t token.TokenType) bool {
+	return p.curToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.TokenType) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) expectPeek(t token.TokenType) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	} else {
+		return false
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,67 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/sam8helloworld/uwscgo/ast"
+	"github.com/sam8helloworld/uwscgo/lexer"
+	"github.com/sam8helloworld/uwscgo/parser"
+)
+
+func TestDimStatements(t *testing.T) {
+	input := `
+DIM valA = 5
+DIM valB = 6
+DIM valC = 7
+	`
+	l := lexer.NewLexer(input)
+	p := parser.NewParser(l)
+
+	program := p.ParseProgram()
+	if program == nil {
+		t.Fatalf("ParseProgram() returned nil")
+	}
+	if len(program.Statements) != 3 {
+		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statements))
+	}
+
+	tests := []struct {
+		expectedIdentifier string
+	}{
+		{"valA"},
+		{"valB"},
+		{"valC"},
+	}
+
+	for i, tt := range tests {
+		stmt := program.Statements[i]
+		if !testDimStatement(t, stmt, tt.expectedIdentifier) {
+			return
+		}
+	}
+}
+
+func testDimStatement(t *testing.T, s ast.Statement, name string) bool {
+	if s.TokenLiteral() != "DIM" {
+		t.Errorf("s.TokenLiteral() not 'DIM'. got=%q", s.TokenLiteral())
+		return false
+	}
+
+	dimStmt, ok := s.(*ast.DimStatement)
+	if !ok {
+		t.Errorf("s not *ast.DimStatement. got=%T", s)
+		return false
+	}
+
+	if dimStmt.Name.Value != name {
+		t.Errorf("dimStmt.Name.Value not '%s'. got=%s", name, dimStmt.Name.Value)
+		return false
+	}
+
+	if dimStmt.Name.TokenLiteral() != name {
+		t.Errorf("dimStmt.Name.TokenLiteral() not '%s'. got=%s", name, dimStmt.Name.TokenLiteral())
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
#5 

文のIdentifierは基本的なローマ字文字列にしか対応しておらず、`val5`のような数字まじりのものは今回解析できない