### PR TITLE
連想配列の宣言を構文解析できるようにする

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -243,6 +243,30 @@ func (rs *ResultStatement) String() string {
 	return rs.Token.Literal
 }
 
+type HashTableStatement struct {
+	Token token.Token
+	Name  *Identifier
+	Value Expression
+}
+
+func (hts *HashTableStatement) statementNode() {}
+func (hts *HashTableStatement) TokenLiteral() string {
+	return hts.Token.Literal
+}
+func (hts *HashTableStatement) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(hts.TokenLiteral() + " ")
+	out.WriteString(hts.Name.String())
+	out.WriteString(" = ")
+
+	if hts.Value != nil {
+		out.WriteString(hts.Value.String())
+	}
+
+	return out.String()
+}
+
 /////////////// Expression
 type Identifier struct {
 	Token token.Token // token.IDENT

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -115,6 +115,8 @@ func (p *Parser) parseStatement() ast.Statement {
 		return p.parseDimStatement()
 	case token.CONST:
 		return p.parseConstStatement()
+	case token.HASHTBL:
+		return p.parseHashTableStatement()
 	case token.IF:
 		return p.parseIfStatement()
 	case token.IFB:
@@ -183,6 +185,29 @@ func (p *Parser) parseConstStatement() *ast.ConstStatement {
 			p.nextToken()
 		}
 	}
+	return stmt
+}
+
+func (p *Parser) parseHashTableStatement() *ast.HashTableStatement {
+	stmt := &ast.HashTableStatement{Token: p.curToken}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+
+	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+
+	if !p.expectPeek(token.EQUAL_OR_ASSIGN) {
+		return nil
+	}
+
+	p.nextToken()
+
+	stmt.Value = p.parseExpression(LOWEST, false)
+
+	if p.peekTokenIs(token.EOL) {
+		p.nextToken()
+	}
+
 	return stmt
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -567,7 +567,7 @@ func (p *Parser) parseCallArguments() []ast.Expression {
 	p.nextToken()
 
 	args = append(args, p.parseExpression(LOWEST, false))
-	fmt.Println(p.curToken)
+
 	for p.peekTokenIs(token.COMMA) {
 		p.nextToken()
 		// カンマが連続

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1159,3 +1159,26 @@ func TestParsingArrayAssign(t *testing.T) {
 		t.Errorf("value.Value is not 1. got=%d", index.Value)
 	}
 }
+
+func TestHashTableStatement(t *testing.T) {
+	input := `HASHTBL val = HASH_CASECARE`
+
+	l := lexer.NewLexer(input)
+	p := parser.NewParser(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt, ok := program.Statements[0].(*ast.HashTableStatement)
+	if !ok {
+		t.Fatalf("stmt not ast.HashTableStatement. got=%T", program.Statements[0])
+	}
+
+	if stmt.Name.Value != "val" {
+		t.Errorf("stmt.Name.Value is not val. got=%s", stmt.Name.Value)
+	}
+
+	val := stmt.Value
+	if !testIdentifier(t, val, "HASH_CASECARE") {
+		return
+	}
+}

--- a/token/token.go
+++ b/token/token.go
@@ -29,6 +29,8 @@ const (
 	PUBLIC = "PUBLIC"
 	CONST  = "CONST"
 
+	HASHTBL = "HASHTBL"
+
 	TRUE  = "TRUE"
 	FALSE = "FALSE"
 
@@ -85,6 +87,7 @@ var reservedWords = map[string]TokenType{
 	"DIM":       DIM,
 	"PUBLIC":    PUBLIC,
 	"CONST":     CONST,
+	"HASHTBL":   HASHTBL,
 	"TRUE":      TRUE,
 	"FALSE":     FALSE,
 	"MOD":       MOD,


### PR DESCRIPTION
構文解析だけではなく評価も実装しようとしたが、評価の実装は複雑性が高かったので別に実装する